### PR TITLE
Fix: Webpack SPA routes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,8 @@ module.exports = {
   },
   devServer: {
     contentBase: path.join(__dirname, "dist"),
+    publicPath: "/",
+    historyApiFallback: true,
     compress: true,
     port: 3001,
   },


### PR DESCRIPTION
Fixes issues with fetching pages when hitting non-root paths. Since all the routing is handled by the client and `/dream` doesn't refer to an actual file, it results in a 404 when using webpack-dev-server.

regular node serving is unaffected by this.